### PR TITLE
Substitute UW link in place of Madison Linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
                     <li>Green Bay Linux Users Group <a href="https://groups.google.com/forum/?fromgroups#!forum/green-bay-linux-users-group">https://groups.google.com/forum/?fromgroups#!forum/green-bay-linux-users-group</a></li>
                     <li>Kenosha Area Linux Users Group <a href="http://www.kenoshalinux.org/">http://www.kenoshalinux.org/</a></li>
                     <li>La Crosse Linux Users Group <a href="http://groups.google.com/group/lacrosselug">http://groups.google.com/group/lacrosselug</a></li>
-                    <li>Madison Linux Users Group <a href="http://www.madisonlinux.org/">http://www.madisonlinux.org/</a></li>
+                    <li>University of Wisconsin-Madison Linux Users Group <a href="https://win.wisc.edu/organization/wisclug">https://win.wisc.edu/organization/wisclug</a></li>
                     <li>Milwaukee Linux Users Group <a href="http://www.milwaukeelug.org/">http://www.milwaukeelug.org/</a></li>
                     <li>Walworth County LUG <a href="http://walworthcountylug.wordpress.com">http://walworthcountylug.wordpress.com</a></li>
                     <li>Wisconsin LoCo Team is a group of folks that &lt;3 Ubuntu. <a href="https://wiki.ubuntu.com/WisconsinTeam">https://wiki.ubuntu.com/WisconsinTeam</a></li>


### PR DESCRIPTION
madisonlinux.org seems to currently be owned by some German anti-virus org. After some research, it looks like the only LUG in Madison right now is at the university.